### PR TITLE
Added central smslibrary repo as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "smslibrary"]
+	path = smslibrary
+	url = https://github.com/Cogno-IDU/smslibrary


### PR DESCRIPTION
Creating a setup for everyone to find: when this gets integrated into the central repo, every clone will automatically see this changes, meaning every clone of the killer app will see the sms library as a submodule